### PR TITLE
Removed double angle right icon from html content.

### DIFF
--- a/views/templates/hook/hook.tpl
+++ b/views/templates/hook/hook.tpl
@@ -42,7 +42,7 @@
 						{/if}
 						{if $hItem.html}
 							<div class="item-html">
-								{$hItem.html} <i class="icon-double-angle-right"></i>
+								{$hItem.html}
 							</div>
 						{/if}
 					{if $hItem.url}


### PR DESCRIPTION
I think that, if you want an angle icon to appear there, you should include it in $hItem.html instead of showing by default, as there is no option to hide it.